### PR TITLE
Write out all errors of same type

### DIFF
--- a/CodeFileSanity/Program.cs
+++ b/CodeFileSanity/Program.cs
@@ -126,15 +126,7 @@ namespace CodeFileSanity
 
         private static int getLineNumber(string input, int index) => input.Remove(index).Count(c => c == '\n') + 1;
 
-        private static void report(string filename, string message, List<int> lines)
-        {
-            lines.ForEach((line) => Console.WriteLine($"{filename}:{line}: {message}"));
-
-            hasErrors = true;
-
-            if (hasAppveyor)
-                lines.ForEach((line) => runAppveyor($"\"{message}\" -Category Error -FileName \"{filename.Substring(2)}\" -Line {line}"));
-        }
+        private static void report(string filename, string message, List<int> lines) => lines.ForEach((line) => report(filename, message, line));
 
         private static void report(string filename, string message, int line = 0)
         {

--- a/CodeFileSanity/Program.cs
+++ b/CodeFileSanity/Program.cs
@@ -107,7 +107,7 @@ namespace CodeFileSanity
             if (Path.GetFileName(file) == "AssemblyInfo.cs")
                 return;
 
-            if (findMatchingLines(text, $"(enum|struct|class|interface) {Path.GetFileNameWithoutExtension(file).Split('_').First()}").Count > 0)
+            if (findMatchingLines(text, $"(enum|struct|class|interface) {Path.GetFileNameWithoutExtension(file).Split('_').First()}").Count == 0)
             {
                 report(file, $"Filename does not match contained type.");
             }


### PR DESCRIPTION
There was talk about CodeFileSanity writing out only one error per file. This changes that behavior. I have no way to check if this works for AppVeyor tho