### PR TITLE
Fix record classes not supported

### DIFF
--- a/CodeFileSanity/CodeSanityValidator.cs
+++ b/CodeFileSanity/CodeSanityValidator.cs
@@ -117,7 +117,7 @@ namespace CodeFileSanity
             if (Path.GetFileName(file) == "AssemblyInfo.cs")
                 return;
 
-            if (findMatchingLines(text, $"(enum|struct|class|interface) {Path.GetFileNameWithoutExtension(file).Split('_').First()}").Count == 0)
+            if (findMatchingLines(text, $"(enum|struct|class|interface|record) {Path.GetFileNameWithoutExtension(file).Split('_').First()}").Count == 0)
             {
                 report(file, $"Filename does not match contained type.");
             }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: '{build}'
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration: Release
 build_script:
   - dotnet pack /p:Version=0.0.%APPVEYOR_BUILD_VERSION% /p:GenerateDocumentationFile=true


### PR DESCRIPTION
Record classes can be (and are required to be according to our R# linting rules) specified without the `class` keyword, e.g:

```csharp
public record MyClass { }
```